### PR TITLE
(feat) Add global prefix for later nginx settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.setGlobalPrefix('api');
 
   const config = new DocumentBuilder()
     .setTitle('Collact API')


### PR DESCRIPTION
나중에 한 서버에서 front / back 둘다 띄워서 통신하게 하려면, nginx에서 설정할때 모든 backend API 들이 하나의 prefix 밑에 있는 것이 유용합니다. 이에 따라 global prefix를 'api'로 설정합니다.

예시:
- /ping -> /api/ping
- /users -> /api/users
- /profiles -> /api/profiles